### PR TITLE
Extend inference timing to include rollout

### DIFF
--- a/baskerville/dawn-comparison/inference-timing.py
+++ b/baskerville/dawn-comparison/inference-timing.py
@@ -91,7 +91,8 @@ def main(steps):
             time_start = time.time()
 
     avg_time = sum(times[1:]) / len(times[1:]) # Exclude the first step time
-    print(f"Average time for {steps} steps: {avg_time}")
+    print(f"Average time for last {steps - 1} steps: {avg_time}")
+    print(f"Total time for {steps} steps: {sum(times)}")
 
     import pickle
 

--- a/dawn/scripts/inference.py
+++ b/dawn/scripts/inference.py
@@ -88,7 +88,8 @@ def main(steps):
             time_start = time.time()
 
     avg_time = sum(times[1:]) / len(times[1:])  # Exclude the first step time
-    print(f"Average time for {steps} steps: {avg_time}")
+    print(f"Average time for last {steps - 1} steps: {avg_time}")
+    print(f"Total time for {steps} steps: {sum(times)}")
 
     import pickle
 


### PR DESCRIPTION
Widen the period captured by the timing measurement to include the rollout step.