### PR TITLE
Add batch scripts for running bandwidth tests on Baskerville

### DIFF
--- a/train/batch/bask-local-diskbw.sh
+++ b/train/batch/bask-local-diskbw.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# vim: et:ts=4:sts=4:sw=4
+
+# Execute using:
+# sbatch ./bask-local-diskbw.sh
+
+echo "## Aurora disk bandwidth script starting"
+
+# Quit on error
+set -e
+
+pushd ../scripts
+
+if [ ! -d ../../downloads ]; then
+  echo "Please run the batch-download.sh script to download the data."
+  exit 1
+fi
+
+echo "## Loading modules"
+
+module -q purge
+module -q load baskerville
+module -q load bask-apps/live
+module -q load PyTorch/2.0.1-foss-2022a-CUDA-11.7.0
+module -q load torchvision/0.15.2-foss-2022a-CUDA-11.7.0
+
+echo "## Configuring environment"
+
+export OMP_NUM_THREADS=1
+
+echo "## Initialising virtual environment"
+
+python3 -m venv venv
+. ./venv/bin/activate
+
+pip install --quiet --upgrade pip
+pip install --quiet xarray==2023.1.0
+pip install --quiet dask==2025.5.1
+pip install --quiet typing-extensions==4.14.0
+pip install --quiet -e ../../aurora
+
+echo "## Running model"
+
+# Perform the prediction
+python timing_data_transfer.py -d ../../downloads --dask
+
+echo "## Tidying up"
+
+deactivate
+popd
+
+echo "## Aurora disk bandwidth script completed"

--- a/train/batch/bask-local-gpubw.sh
+++ b/train/batch/bask-local-gpubw.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# vim: et:ts=4:sts=4:sw=4
+
+# Execute using:
+# sbatch ./bask-local-gpubw.sh
+
+echo "## Aurora GPU bandwidth script starting"
+
+# Quit on error
+set -e
+
+pushd ../scripts
+
+echo "## Loading modules"
+
+module -q purge
+module -q load baskerville
+module -q load bask-apps/live
+module -q load PyTorch/2.0.1-foss-2022a-CUDA-11.7.0
+module -q load torchvision/0.15.2-foss-2022a-CUDA-11.7.0
+
+echo "## Configuring environment"
+
+export OMP_NUM_THREADS=1
+
+echo "## Initialising virtual environment"
+
+python3 -m venv venv
+. ./venv/bin/activate
+
+pip install --quiet --upgrade pip
+pip install --quiet typing-extensions==4.14.0
+
+echo "## Running model"
+
+# Perform the prediction
+python timing_gpu_bandwidth.py --device "gpu"
+
+echo "## Tidying up"
+
+deactivate
+popd
+
+echo "## Aurora GPU bandwidth script completed"


### PR DESCRIPTION
Adds a couple of batch scripts for running the disk and GPU bandwidth tests on Baskerville. The same code is used, the scripts just perform set up of the environment and so on.

These scripts are for use with srun rather than sbatch (i.e. they expect to be run directly from a compute note on Baskerville).

This should be rebased and retargeted once #19 has been merged in.