### PR TITLE
Adds aurora_hpc into the Python path

### DIFF
--- a/train/batch/bask-local-train-fsdp.sh
+++ b/train/batch/bask-local-train-fsdp.sh
@@ -27,6 +27,7 @@ module -q load torchvision/0.15.2-foss-2022a-CUDA-11.7.0
 echo "## Configuring environment"
 
 export OMP_NUM_THREADS=1
+export PYTHONPATH=${PWD}/../../src/:$PYTHONPATH
 
 echo "## Initialising virtual environment"
 

--- a/train/batch/bask-train-fsdp.sh
+++ b/train/batch/bask-train-fsdp.sh
@@ -43,6 +43,7 @@ echo "## Configuring environment"
 export PRIMARY_PORT=$((16384 + $RANDOM % 16384))
 export PRIMARY_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
 export OMP_NUM_THREADS=1
+export PYTHONPATH=${PWD}/../../src/:$PYTHONPATH
 
 echo
 echo "## Initialising virtual environment"


### PR DESCRIPTION
In order to allow the aurora_hpc imports to work on Baskerville without having to install the dependencies listed in pyproject.toml, this adds the aurora_hpc directory to the Python path.

This allows the Baskerville training code to run with minimal changes on Baskerville.

Closes #39.