### PR TITLE
[Alternate] Update Dawn environment for RHEL9

### DIFF
--- a/train/batch/dawn-create-venv.sh
+++ b/train/batch/dawn-create-venv.sh
@@ -24,16 +24,14 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel9
 
 echo
 echo "## Initialising virtual environment"
@@ -44,6 +42,7 @@ python3.11 -m venv $VENV_DIR
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-1x1.sh
+++ b/train/batch/dawn-train-ddp-1x1.sh
@@ -32,19 +32,14 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
-
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel9
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -61,8 +56,6 @@ export ZES_ENABLE_SYSMAN=1
 
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
-
-sycl-ls
 
 echo
 echo "## Initialising virtual environment"

--- a/train/batch/dawn-train-ddp-1x4.sh
+++ b/train/batch/dawn-train-ddp-1x4.sh
@@ -32,16 +32,14 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel9
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -67,6 +65,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-2x4.sh
+++ b/train/batch/dawn-train-ddp-2x4.sh
@@ -32,19 +32,14 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
-
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel9
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -62,8 +57,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +65,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-2x8.sh
+++ b/train/batch/dawn-train-ddp-2x8.sh
@@ -33,19 +33,14 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
-
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel9
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -63,8 +58,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -73,6 +66,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-4x4.sh
+++ b/train/batch/dawn-train-ddp-4x4.sh
@@ -32,19 +32,14 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
-
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel9
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -62,8 +57,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +65,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-4x8.sh
+++ b/train/batch/dawn-train-ddp-4x8.sh
@@ -32,19 +32,14 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
-
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel9
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -62,8 +57,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +65,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp.sh
+++ b/train/batch/dawn-train-ddp.sh
@@ -32,14 +32,9 @@ echo
 echo "## Loading modules"
 
 module purge
-module load default-dawn
-module load lua
-module load intel-oneapi-ccl/2021.14.0
-module load intel-oneapi-mpi/2021.14.1
-module load intel-oneapi-mkl/2025.0.1
-
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
+module load rhel9/default-dawn
+module load intel-oneapi-mkl/2025.1.0
+module load intel-oneapi-ccl/2021.15.0
 
 echo
 echo "## Configuring environment"
@@ -62,8 +57,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +65,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"


### PR DESCRIPTION
Updates the runtime environment to use RHEL9 as suggested by the Dawn team, to provide comparative timing results.