### PR TITLE
Make RHEL8 sbatch scripts explicit and consistent

### DIFF
--- a/train/batch/dawn-create-venv.sh
+++ b/train/batch/dawn-create-venv.sh
@@ -25,7 +25,7 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
@@ -33,7 +33,7 @@ module load intel-oneapi-mkl/2025.0.1
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 echo
 echo "## Initialising virtual environment"
@@ -44,6 +44,7 @@ python3.11 -m venv $VENV_DIR
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-1x1.sh
+++ b/train/batch/dawn-train-ddp-1x1.sh
@@ -33,18 +33,15 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
 
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
-
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -61,8 +58,6 @@ export ZES_ENABLE_SYSMAN=1
 
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
-
-sycl-ls
 
 echo
 echo "## Initialising virtual environment"

--- a/train/batch/dawn-train-ddp-1x4.sh
+++ b/train/batch/dawn-train-ddp-1x4.sh
@@ -33,7 +33,7 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
@@ -41,7 +41,7 @@ module load intel-oneapi-mkl/2025.0.1
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -67,6 +67,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-2x4.sh
+++ b/train/batch/dawn-train-ddp-2x4.sh
@@ -33,18 +33,15 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
 
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
-
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -62,8 +59,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +67,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-2x8.sh
+++ b/train/batch/dawn-train-ddp-2x8.sh
@@ -34,18 +34,15 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
 
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
-
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -63,8 +60,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -73,6 +68,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-4x4.sh
+++ b/train/batch/dawn-train-ddp-4x4.sh
@@ -33,18 +33,15 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
 
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
-
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -62,8 +59,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +67,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp-4x8.sh
+++ b/train/batch/dawn-train-ddp-4x8.sh
@@ -33,18 +33,15 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
 
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
-
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -62,8 +59,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +67,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"

--- a/train/batch/dawn-train-ddp.sh
+++ b/train/batch/dawn-train-ddp.sh
@@ -33,18 +33,15 @@ echo "## Loading modules"
 
 module purge
 module load default-dawn
-module load lua
+module load lua/5.3.6/gcc/vlcrcwvl
 module load intel-oneapi-ccl/2021.14.0
 module load intel-oneapi-mpi/2021.14.1
 module load intel-oneapi-mkl/2025.0.1
 
-# load intel oneapi compilers (gives us sycl-ls command)
-module load intel-oneapi-compilers/2025.0.3/gcc/sb5vj5us
-
 echo
 echo "## Configuring environment"
 
-VENV_DIR=../../dawn/environments/venv_3_11_11
+VENV_DIR=../../dawn/environments/venv_3_11_11_rhel8
 
 # Merge tiles into full devices, for extra memory.
 export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
@@ -62,8 +59,6 @@ export ZES_ENABLE_SYSMAN=1
 # Otherwise we're told to.
 export CCL_ZE_IPC_EXCHANGE=sockets
 
-sycl-ls
-
 echo
 echo "## Initialising virtual environment"
 
@@ -72,6 +67,7 @@ source ${VENV_DIR}/bin/activate
 echo
 echo "## Details"
 echo
+echo "Date: $(date)"
 echo "Nodes: ${SLURM_JOB_NUM_NODES}"
 echo "GPUs per node: ${SLURM_GPUS_PER_NODE}"
 echo "Tasks per node: ${SLURM_NTASKS_PER_NODE}"


### PR DESCRIPTION
Makes the lua version explicit in the scripts used to queue jobs using sbatch for the RHEL8 variant. Also removes an unused module load.

This goes alongside the changes in #56. The RHEL9 branch isn't intended to be merged in, but is instead to allow the two versions to be compared.